### PR TITLE
Add Flask web UI and modular core for Obsidian note generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,34 @@
 # Obsidian Note Generator
 
-Generate Obsidian-friendly notes using a two step process: a metadata call followed by a rich body call.
+Generate Obsidian-friendly notes using a two step process: a metadata call
+followed by a rich body call. A small web UI lets you drag-and-drop a CSV of
+subjects or type a single subject.
 
-## Configuration
+## Quick start
 
-The tool talks to a local API. Defaults are baked into the code but can be overridden via environment variables or a `.env` file copied from `.env.example`.
-
-* `API_URL` – API endpoint (default `http://192.168.50.4:8787/infer`)
-* `NOTES_DIR` – where notes are written
-* `PER_REQUEST_DELAY_SECONDS` – spacing between CSV subjects
-* `DELAY_BETWEEN_CALLS_SECONDS` – delay between metadata/body calls
-
-## Installation
-
-Install with `pipx` or via Docker.
+Install with [`pipx`](https://pypa.github.io/pipx/):
 
 ```bash
-pipx install .
-# or
-pipx run obsidian-note-gen "Ancient Bridges"
+pipx install git+https://github.com/<you>/obsidian-note-gen.git
 ```
 
-### Docker
+Run the app:
 
 ```bash
-docker build -t obsidian-note-gen:latest .
-docker run --rm -e API_URL=http://192.168.50.4:8787/infer \
-  -e NOTES_DIR=/notes \
-  -v "$HOME/Notes":/notes \
-  obsidian-note-gen:latest "Ancient Bridges"
+obsidian-note-gen
 ```
 
-## Usage
+It opens `http://127.0.0.1:8789` in your browser (or prints the URL). Set your
+API URL and notes directory in the UI, then either type a subject or
+drag-and-drop a CSV file (first column = subject). The application waits 30 s
+between the metadata and body calls and 120 s between CSV rows by default.
 
-Generate a single subject:
+The API is expected to return JSON envelopes like:
 
-```bash
-obsidian-note-gen "Ancient Bridges"
+```json
+{"ok": true, "output": "..."}
 ```
 
-Or process a CSV of subjects spaced apart by `PER_REQUEST_DELAY_SECONDS`:
+Generated Markdown notes contain YAML front matter compatible with
+Obsidian's Properties view.
 
-```bash
-obsidian-note-gen --file subjects.csv
-```
-
-The resulting Markdown contains YAML front matter suitable for Obsidian's Properties view.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "obsidian-note-gen"
 version = "0.1.0"
-description = "Two-call Obsidian note generator (metadata then rich content)"
+description = "Two-call Obsidian note generator with a web UI"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"
 authors = [{ name = "Your Name" }]
-dependencies = []
+dependencies = ["Flask>=3.0"]
 
 [project.scripts]
-obsidian-note-gen = "obsidian_note_gen.cli:main"
+obsidian-note-gen = "obsidian_note_gen.webapp:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/obsidian_note_gen/__init__.py
+++ b/src/obsidian_note_gen/__init__.py
@@ -1,5 +1,7 @@
 """Obsidian note generator package."""
 
-__all__ = []
+from .core import Delays, process_csv, process_subject
+
+__all__ = ["Delays", "process_subject", "process_csv"]
 
 __version__ = "0.1.0"

--- a/src/obsidian_note_gen/config.py
+++ b/src/obsidian_note_gen/config.py
@@ -1,0 +1,41 @@
+"""Simple config loader/saver."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from .core import DEFAULT_API_URL, DEFAULT_NOTES_DIR, Delays
+
+
+CONFIG_PATH = Path("~/.config/obsidian-note-gen/config.json").expanduser()
+
+
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        try:
+            data = json.loads(CONFIG_PATH.read_text("utf-8"))
+            return {
+                "api_url": data.get("api_url", DEFAULT_API_URL),
+                "notes_dir": data.get("notes_dir", DEFAULT_NOTES_DIR),
+                "delay_meta_content": int(data.get("delay_meta_content", Delays().meta_to_content)),
+                "delay_between_rows": int(data.get("delay_between_rows", Delays().between_rows)),
+            }
+        except Exception:
+            pass
+    return {
+        "api_url": DEFAULT_API_URL,
+        "notes_dir": DEFAULT_NOTES_DIR,
+        "delay_meta_content": Delays().meta_to_content,
+        "delay_between_rows": Delays().between_rows,
+    }
+
+
+def save_config(cfg: dict) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(cfg, indent=2), "utf-8")
+
+
+__all__ = ["load_config", "save_config", "CONFIG_PATH"]
+

--- a/src/obsidian_note_gen/static/app.js
+++ b/src/obsidian_note_gen/static/app.js
@@ -1,0 +1,46 @@
+function getConfig() {
+  return {
+    api_url: document.getElementById('api_url').value,
+    notes_dir: document.getElementById('notes_dir').value,
+    delay_meta_content: document.getElementById('delay_meta').value,
+    delay_between_rows: document.getElementById('delay_rows').value,
+  };
+}
+
+document.getElementById('one-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = new FormData();
+  const cfg = getConfig();
+  Object.entries(cfg).forEach(([k, v]) => data.append(k, v));
+  data.append('subject', document.getElementById('subject').value);
+  const res = await fetch('/run-one', { method: 'POST', body: data });
+  const js = await res.json();
+  document.getElementById('log').textContent = 'Created ' + js.path;
+});
+
+const drop = document.getElementById('drop-zone');
+const fileInput = document.getElementById('csvfile');
+
+drop.addEventListener('click', () => fileInput.click());
+drop.addEventListener('dragover', (e) => {
+  e.preventDefault();
+});
+drop.addEventListener('drop', (e) => {
+  e.preventDefault();
+  fileInput.files = e.dataTransfer.files;
+  uploadCSV();
+});
+fileInput.addEventListener('change', uploadCSV);
+
+async function uploadCSV() {
+  const file = fileInput.files[0];
+  if (!file) return;
+  const data = new FormData();
+  const cfg = getConfig();
+  Object.entries(cfg).forEach(([k, v]) => data.append(k, v));
+  data.append('file', file);
+  const res = await fetch('/upload', { method: 'POST', body: data });
+  const js = await res.json();
+  document.getElementById('log').textContent = js.paths.join('\n');
+}
+

--- a/src/obsidian_note_gen/templates/index.html
+++ b/src/obsidian_note_gen/templates/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Obsidian Note Generator</title>
+    <script src="{{ url_for('static', filename='app.js') }}" defer></script>
+    <style>
+      #drop-zone {
+        border: 2px dashed #999;
+        padding: 20px;
+        text-align: center;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Obsidian Note Generator</h1>
+    <label>API URL <input id="api_url" value="{{ config.api_url }}" /></label><br />
+    <label>Notes directory <input id="notes_dir" value="{{ config.notes_dir }}" /></label><br />
+    <label>Delay meta→content (s) <input id="delay_meta" type="number" value="{{ config.delay_meta_content }}" /></label><br />
+    <label>Delay between CSV rows (s) <input id="delay_rows" type="number" value="{{ config.delay_between_rows }}" /></label><br />
+
+    <h3>Create single note</h3>
+    <form id="one-form">
+      <input id="subject" name="subject" placeholder="Subject" />
+      <button type="submit">Create Note</button>
+    </form>
+
+    <h3>Upload CSV</h3>
+    <div id="drop-zone">Drop CSV here or click to select</div>
+    <input type="file" id="csvfile" style="display:none" accept=".csv" />
+
+    <pre id="log"></pre>
+  </body>
+</html>
+

--- a/src/obsidian_note_gen/webapp.py
+++ b/src/obsidian_note_gen/webapp.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Flask web UI for the note generator."""
+
+from pathlib import Path
+import webbrowser
+from flask import Flask, jsonify, render_template, request
+
+from .config import load_config, save_config
+from .core import Delays, process_csv, process_subject
+
+
+BASE_DIR = Path(__file__).resolve().parent
+app = Flask(
+    __name__,
+    template_folder=str(BASE_DIR / "templates"),
+    static_folder=str(BASE_DIR / "static"),
+)
+
+
+def _config_from_request(cfg: dict) -> tuple[str, str, Delays]:
+    api_url = request.form.get("api_url") or cfg["api_url"]
+    notes_dir = request.form.get("notes_dir") or cfg["notes_dir"]
+    delay_meta = int(request.form.get("delay_meta_content") or cfg["delay_meta_content"])
+    delay_rows = int(request.form.get("delay_between_rows") or cfg["delay_between_rows"])
+    new_cfg = {
+        "api_url": api_url,
+        "notes_dir": notes_dir,
+        "delay_meta_content": delay_meta,
+        "delay_between_rows": delay_rows,
+    }
+    save_config(new_cfg)
+    return api_url, notes_dir, Delays(delay_meta, delay_rows)
+
+
+@app.get("/")
+def index():
+    cfg = load_config()
+    return render_template("index.html", config=cfg)
+
+
+@app.post("/run-one")
+def run_one():
+    cfg = load_config()
+    api_url, notes_dir, delays = _config_from_request(cfg)
+    subject = request.form.get("subject", "")
+    path = process_subject(subject, api_url=api_url, notes_dir=notes_dir, delays=delays)
+    return jsonify({"path": path})
+
+
+@app.post("/upload")
+def upload_csv():
+    cfg = load_config()
+    api_url, notes_dir, delays = _config_from_request(cfg)
+    file = request.files.get("file")
+    if not file:
+        return jsonify({"paths": []})
+    paths = process_csv(file.stream, api_url=api_url, notes_dir=notes_dir, delays=delays)
+    return jsonify({"paths": paths})
+
+
+def main() -> None:
+    cfg = load_config()
+    url = "http://127.0.0.1:8789"
+    print(f"Open {url}")
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass
+    app.run(port=8789)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,10 @@
 import json
 from unittest.mock import patch
 
-from obsidian_note_gen import cli
+from obsidian_note_gen import core
 
 
-def fake_infer_meta(prompt: str) -> str:
+def fake_infer_meta(_):
     return json.dumps(
         {
             "title": "Ancient Bridges",
@@ -15,20 +15,19 @@ def fake_infer_meta(prompt: str) -> str:
     )
 
 
-def fake_infer_body(prompt: str) -> str:
+def fake_infer_body(_):
     return "Body text " + ("x" * 1200)
 
 
-@patch(
-    "obsidian_note_gen.cli.api_infer",
-    side_effect=[fake_infer_meta(""), fake_infer_body("")],
-)
-def test_single_subject(mock_infer, tmp_path, monkeypatch):
-    monkeypatch.setenv("NOTES_DIR", str(tmp_path))
-    monkeypatch.setenv("DELAY_BETWEEN_CALLS_SECONDS", "0")
-    path = cli.process_subject("Ancient Bridges")
+@patch("obsidian_note_gen.core.api_infer", side_effect=[fake_infer_meta(""), fake_infer_body("")])
+def test_single_subject(mock_infer, tmp_path):
+    delays = core.Delays(meta_to_content=0, between_rows=0)
+    path = core.process_subject(
+        "Ancient Bridges", api_url="http://example", notes_dir=str(tmp_path), delays=delays
+    )
     assert path and (tmp_path / "ancient-bridges.md").exists()
     data = (tmp_path / "ancient-bridges.md").read_text()
     assert 'title: "Ancient Bridges"' in data
     assert "tags: [" in data
     assert "Body text" in data
+


### PR DESCRIPTION
## Summary
- refactor original script into `core` module with `process_subject` and `process_csv`
- add config handling and Flask web interface with drag-and-drop CSV support
- update packaging to expose `obsidian-note-gen` command

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689efef5cd10832791defbaf1fe325e3