### PR TITLE
Add dark mode and auto update on launch

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,12 +1,26 @@
 """Run the Obsidian Note Generator web UI without installing the package."""
 
 from pathlib import Path
+import subprocess
 import sys
 
+BASE_DIR = Path(__file__).resolve().parent
+
+
+def auto_update() -> None:
+    """Fetch updates from the remote repository."""
+    try:
+        subprocess.run(["git", "pull"], cwd=BASE_DIR, check=True)
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Auto-update skipped: {exc}")
+
+
 # Add the src directory to the Python path so imports work from a source checkout
-sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
+sys.path.insert(0, str(BASE_DIR / "src"))
 
 from obsidian_note_gen.webapp import main
 
+
 if __name__ == "__main__":
+    auto_update()
     main()

--- a/src/obsidian_note_gen/static/app.js
+++ b/src/obsidian_note_gen/static/app.js
@@ -7,6 +7,19 @@ function getConfig() {
   };
 }
 
+function applyTheme(dark) {
+  document.body.classList.toggle('dark', dark);
+  localStorage.setItem('theme', dark ? 'dark' : 'light');
+}
+
+const themeToggle = document.getElementById('dark-toggle');
+if (themeToggle) {
+  themeToggle.addEventListener('change', () => applyTheme(themeToggle.checked));
+  const saved = localStorage.getItem('theme') === 'dark';
+  themeToggle.checked = saved;
+  applyTheme(saved);
+}
+
 document.getElementById('one-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const data = new FormData();

--- a/src/obsidian_note_gen/templates/index.html
+++ b/src/obsidian_note_gen/templates/index.html
@@ -5,6 +5,21 @@
     <title>Obsidian Note Generator</title>
     <script src="{{ url_for('static', filename='app.js') }}" defer></script>
     <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body.dark {
+        background-color: #121212;
+        color: #e0e0e0;
+      }
+      body.dark input,
+      body.dark button,
+      body.dark textarea,
+      body.dark select {
+        background-color: #333;
+        color: #e0e0e0;
+        border-color: #555;
+      }
       #drop-zone {
         border: 2px dashed #999;
         padding: 20px;
@@ -15,6 +30,7 @@
   </head>
   <body>
     <h1>Obsidian Note Generator</h1>
+    <label><input type="checkbox" id="dark-toggle" /> Dark mode</label><br />
     <label>API URL <input id="api_url" value="{{ config.api_url }}" /></label><br />
     <label>Notes directory <input id="notes_dir" value="{{ config.notes_dir }}" /></label><br />
     <label>Delay meta→content (s) <input id="delay_meta" type="number" value="{{ config.delay_meta_content }}" /></label><br />
@@ -33,4 +49,3 @@
     <pre id="log"></pre>
   </body>
 </html>
-


### PR DESCRIPTION
## Summary
- add dark mode styles and toggle with persistent preference
- automatically pull latest changes from repository on startup

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f088885f083278ac75e6948dd9f31